### PR TITLE
Add Exilecon Ticket Prices

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -1,6 +1,19 @@
 const elements = document.querySelectorAll(".packageName", ".el", ".FontinBold");
 
 const microtransactions = {
+
+    // Exilecon 2023
+    "Exilecon 2023 Ultra VIP": 2000,
+    "Exilecon 2023 VIP": 700,
+    "Exilecon 2023": 230,
+    "Exilecon 2023 Balcony Ticket": 210,
+
+    // Exilecon 2019
+    "Exilecon Ultra VIP": 1000,
+    "Exilecon VIP": 500,
+    "Exilecon": 200,
+    "Exilecon Balcony Ticket": 180,
+    
     //Necropolis
     "Solar": 30,
     "Solar Knight": 60,


### PR DESCRIPTION
Added the prices for Exilecon, since those are very large amounts of ""MTX" (they did come with exclusive MTX I suppose)

2023 Ticket Prices: https://www.pathofexile.com/forum/view-thread/3293537
* They added Balcony tickets at $20 cheaper later on

2019 ticket prices:  Wayback Machine [1](https://web.archive.org/web/20190329124425/https://www.pathofexile.com/exilecon), [2](https://web.archive.org/web/20191027033300/https://www.pathofexile.com/exilecon)